### PR TITLE
Slightly better way to get correct name for actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore python compiled files
+*.pyc

--- a/ros_opcua_impl_python_opcua/scripts/ros_actions.py
+++ b/ros_opcua_impl_python_opcua/scripts/ros_actions.py
@@ -1,5 +1,6 @@
 # !/usr/bin/python
 # thanks to https://github.com/ros-visualization/rqt_common_plugins/blob/groovy-devel/rqt_action/src/rqt_action/action_plugin.py
+import string
 import random
 from pydoc import locate
 
@@ -344,20 +345,8 @@ class OpcUaROSAction:
 
 def get_correct_name(topic_name):
     rospy.logdebug("getting correct name for: " + str(topic_name))
-    splits = topic_name.split("/")
-    counter = 0
-    counter2 = 0
-    result = ""
-    while counter < len(splits):
-        if splits[-1] == splits[counter] and not counter == 1:
-            while counter2 <= counter - 1:
-                if counter2 != counter - 1:
-                    result += splits[counter2] + '/'
-                else:
-                    result += splits[counter2]
-                counter2 += 1
-            return result
-        counter += 1
+    splits = topic_name.split('/')
+    return string.join(splits[0:-1], '/')
 
 
 def getargarray(goal_class):

--- a/ros_opcua_impl_python_opcua/scripts/ros_topics.py
+++ b/ros_opcua_impl_python_opcua/scripts/ros_topics.py
@@ -266,14 +266,14 @@ def numberofsubscribers(nametolookfor, topicsDict):
     return ret
 
 
-def refresh_topics_and_actions(namespace_ros, server, topicsdict, actionsdict, idx_topics, idx_actions, topics,
-                               actions):
+def refresh_topics_and_actions(namespace_ros, server, topicsdict, actionsdict, idx_topics, idx_actions, topics, actions):
     ros_topics = rospy.get_published_topics(namespace_ros)
     rospy.logdebug(str(ros_topics))
     rospy.logdebug(str(rospy.get_published_topics('/move_base_simple')))
     for topic_name, topic_type in ros_topics:
         if topic_name not in topicsdict or topicsdict[topic_name] is None:
-            if "cancel" in topic_name or "result" in topic_name or "feedback" in topic_name or "goal" in topic_name or "status" in topic_name:
+            splits = topic_name.split('/')
+            if "cancel" in splits[-1] or "result" in splits[-1] or "feedback" in splits[-1] or "goal" in splits[-1] or "status" in splits[-1]:
                 rospy.logdebug("Found an action: " + str(topic_name))
                 correct_name = ros_actions.get_correct_name(topic_name)
                 if correct_name not in actionsdict:
@@ -323,7 +323,7 @@ def get_feedback_type(action_name):
             type, name, fn = rostopic.get_topic_type(action_name + "/Feedback", e)
             return type
         except rospy.ROSException as e2:
-            rospy.logerr("Couldnt find feedback type for action " + action_name, e2)
+            rospy.logerr("Couldn't find feedback type for action " + action_name, e2)
             return None
 
 
@@ -336,5 +336,5 @@ def get_goal_type(action_name):
             type, name, fn = rostopic.get_topic_type(action_name + "/Goal", e)
             return type
         except rospy.ROSException as e2:
-            rospy.logerr("Couldnt find feedback type for action " + action_name, e2)
+            rospy.logerr("Couldn't find goal type for action " + action_name, e2)
             return None


### PR DESCRIPTION
I found that **get_correct_name(...)** method is a bit convoluted for what it's intended for.
I proposed an simple way to rewrite it but I want some feedback on whether some checks it's needed and what's the better way to handle possible exceptions.

In **refresh_topics_and _actions(...)** I think that it would be slightly better to check if 'goal', 'feedback', ... are present only in the last segment of the topic name.